### PR TITLE
external emote fetching fix (pubsub channelId isn't userId)

### DIFF
--- a/TwitchScanAPI/Data/Twitch/Manager/TwitchClientManager.cs
+++ b/TwitchScanAPI/Data/Twitch/Manager/TwitchClientManager.cs
@@ -163,7 +163,7 @@ namespace TwitchScanAPI.Data.Twitch.Manager
                 if (args.ChannelId != _cachedChannelInformation.Id) return;
 
                 IsOnline = true;
-                UpdateChannelEmotes(args.ChannelId);
+                UpdateChannelEmotes(_channelName);
                 Console.WriteLine($"{_channelName} is now online (via PubSub).");
                 OnConnectionChanged?.Invoke(this, _cachedChannelInformation);
                 _ = StartClientAsync();
@@ -187,7 +187,8 @@ namespace TwitchScanAPI.Data.Twitch.Manager
         {
             try
             {
-                ExternalChannelEmotes = await EmoteService.GetChannelEmotesAsync(channelId);
+                var result = Api.Helix.Users.GetUsersAsync(logins:[channelId]);
+                ExternalChannelEmotes = await EmoteService.GetChannelEmotesAsync(result.Result.Users.FirstOrDefault()?.Id);
                 Console.WriteLine($"Loaded {ExternalChannelEmotes?.Count ?? 0} external emotes for {_channelName}");
             }
             catch (Exception ex)


### PR DESCRIPTION
for some strange reason pubsub channelId isn't UserId

noticed it today in chat it wasn't showing emotes (no clue if it was also before or with the pending shutdown)
that it's like this or just never noticed that this happened before